### PR TITLE
auto-import | Adds info about auto import if var is from other file

### DIFF
--- a/lua/typescript-tools/protocol/handlers/completion/resolve.lua
+++ b/lua/typescript-tools/protocol/handlers/completion/resolve.lua
@@ -13,9 +13,7 @@ local completion_resolve_request_handler = function(_, params)
         file = data.file,
         entryNames = data.entryNames,
         source = data.source,
-      }, utils.convert_lsp_position_to_tsserver(
-        data
-      )),
+      }, utils.convert_lsp_position_to_tsserver(data)),
     }
   end
 
@@ -57,8 +55,16 @@ local completion_resolve_response_handler = function(_, body, request_params)
       table.insert(documentation, { text = utils.tsserver_make_tags(details.tags) })
     end
 
+    local detail = utils.tsserver_docs_to_plain_text(details.displayParts)
+
+    -- copied behavior from https://github.com/typescript-language-server/typescript-language-server/blob/70eae7e0885d9b5b7841cad3ba033f3c9c6955d2/src/completion.ts#LL496C18-L496C18
+    local source = details.sourceDisplay or details.deprecatedSource
+    if source and detail then
+      detail = "Auto import from " .. utils.tsserver_docs_to_plain_text(source) .. "\n" .. detail
+    end
+
     return vim.tbl_extend("force", request_params, {
-      detail = utils.tsserver_docs_to_plain_text(details.displayParts),
+      detail = detail,
       documentation = {
         kind = constants.MarkupKind.Markdown,
         value = utils.tsserver_docs_to_plain_text(documentation, "\n"),


### PR DESCRIPTION
What do you think about it?

Copied behavior from https://github.com/typescript-language-server/typescript-language-server/blob/70eae7e0885d9b5b7841cad3ba033f3c9c6955d2/src/completion.ts#LL496C18-L496C18 and I was kinda used to it

<img width="1339" alt="image" src="https://user-images.githubusercontent.com/35625949/226194970-53bcfc40-f457-4f0d-b7f1-3b48e8da9b6c.png">
