### PR TITLE
fix(hover): add correct markdown format to code snippet

### DIFF
--- a/lua/typescript-tools/protocol/text_document/hover.lua
+++ b/lua/typescript-tools/protocol/text_document/hover.lua
@@ -25,8 +25,8 @@ function M.handler(request, response, params)
 
   if body.displayString then
     table.insert(contents, 1, {
-      language = "typescript",
-      value = body.displayString,
+      kind = "markdown",
+      value = "```typescript\n" .. body.displayString .. "\n```",
     })
   end
 

--- a/lua/typescript-tools/protocol/text_document/hover.lua
+++ b/lua/typescript-tools/protocol/text_document/hover.lua
@@ -18,7 +18,6 @@ function M.handler(request, response, params)
   local body = coroutine.yield()
 
   local contents = {
-    "\n",
     utils.tsserver_docs_to_plain_text(body.documentation),
     utils.tsserver_make_tags(body.tags),
   }
@@ -26,7 +25,7 @@ function M.handler(request, response, params)
   if body.displayString then
     table.insert(contents, 1, {
       kind = "markdown",
-      value = "```typescript\n" .. body.displayString .. "\n```",
+      value = "```typescript\n" .. body.displayString .. "\n```\n",
     })
   end
 

--- a/tests/requests_spec.lua
+++ b/tests/requests_spec.lua
@@ -26,7 +26,7 @@ describe("Lsp request", function()
 
     local result = lsp_assert.response(ret)
     assert.is.True(#result.contents >= 1)
-    assert.are.same(result.contents[1].value, "const foo: 1")
+    assert.are.same(result.contents[1].value, "```typescript\nconst foo: 1\n```\n")
     lsp_assert.range(result.range, 3, 8, 3, 11)
   end)
 


### PR DESCRIPTION
Fixes: https://github.com/pmizio/typescript-tools.nvim/issues/118