### PR TITLE
fix: don't snippet-ify function snippets that are already snippet-ified

### DIFF
--- a/lua/typescript-tools/protocol/text_document/completion/init.lua
+++ b/lua/typescript-tools/protocol/text_document/completion/init.lua
@@ -67,7 +67,8 @@ function M.handler(request, response, params)
         sortText = "\u{ffff}" .. item.sortText
       end
 
-      local should_create_function_snippet = utils.should_create_function_snippet(kind, filetype)
+      local should_create_function_snippet =
+        utils.should_create_function_snippet(kind, insertText, filetype)
       local should_create_snippet = item.isSnippet or should_create_function_snippet
       local label = is_optional and (item.name .. "?") or item.name
       label = should_create_function_snippet and (label .. "(...)") or label

--- a/lua/typescript-tools/protocol/text_document/completion/resolve.lua
+++ b/lua/typescript-tools/protocol/text_document/completion/resolve.lua
@@ -93,15 +93,15 @@ local function create_snippet(item, display_parts)
   local snippet =
     string.format("%s(", item.insertText or (item.textEdit and item.textEdit.newText) or item.label)
   for i, part in ipairs(parts) do
-    snippet = snippet .. string.format("${%d:%s}", i, part.text:gsub("([$}\\])", "\\%1"))
+    snippet = snippet .. string.format("${%d:%s}", i - 1, part.text:gsub("([$}\\])", "\\%1"))
     if i ~= #parts then
       snippet = snippet .. ", "
     end
   end
   if has_optional_parameters then
-    snippet = snippet .. string.format("$%d", #parts + 1)
+    snippet = snippet .. string.format("$%d", #parts)
   end
-  snippet = snippet .. ")$0"
+  snippet = snippet .. ")"
   item.insertText = snippet
   item.insertTextFormat = c.InsertTextFormat.Snippet
   if item.textEdit then
@@ -171,7 +171,7 @@ function M.handler(request, response, params)
       -- or neovim even handle that for now i skip this
     })
 
-    if utils.should_create_function_snippet(item.kind, filetype) then
+    if utils.should_create_function_snippet(item.kind, item.insertText, filetype) then
       create_snippet(item, details.displayParts)
     end
 

--- a/lua/typescript-tools/protocol/utils.lua
+++ b/lua/typescript-tools/protocol/utils.lua
@@ -224,14 +224,16 @@ function M.cancelled_response(data)
 end
 
 ---@param kind CompletionItemKind
+---@param insertText string
 ---@param filetype vim.opt.filetype
 ---@return boolean
 ---@see https://github.com/typescript-language-server/typescript-language-server/blob/983a6923114c39d638e0c7d419ae16e8bca8985c/src/completion.ts#L355-L371
-function M.should_create_function_snippet(kind, filetype)
+function M.should_create_function_snippet(kind, insertText, filetype)
   local preferences = plugin_config.get_tsserver_file_preferences(filetype)
   return preferences.includeCompletionsWithSnippetText
-    and (kind == c.CompletionItemKind.Function or kind == c.CompletionItemKind.Method)
     and plugin_config.complete_function_calls
+    and (kind == c.CompletionItemKind.Function or kind == c.CompletionItemKind.Method)
+    and not string.find(insertText, "%$")
 end
 
 ---@param content string

--- a/tests/requests_spec.lua
+++ b/tests/requests_spec.lua
@@ -220,7 +220,7 @@ describe("Lsp request", function()
     result = lsp_assert.response(ret)
 
     assert.is.table(result)
-    assert.are.same(result.insertText, "warn($1)$0")
+    assert.are.same(result.insertText, "warn($0)")
     assert.are.same(result.detail, "(method) Console.warn(...data: any[]): void")
 
     plugin_config.complete_function_calls = prev_config


### PR DESCRIPTION
Contrary to the LSP protocol, we add the snippet insert text at resolve time rather than at list time due to an issue in `tsserver`:

https://github.com/microsoft/TypeScript/issues/51758#issue-1477065873

However, it's only sometimes true that functions need to be snippet-ified at resolve-time. For example, method implementations for subclasses are snippified at list-time, so snippet-ifying them at resolve-time will cause duplication:

https://github.com/pmizio/typescript-tools.nvim/assets/5601392/98f5d655-8068-417a-b10f-4f0253af03d8

note: I also removed the extra $0 at the end of the snippet as that was just blindly copied from `typescript-language-server` but it doesn't add any value.