### PR TITLE
fix(rpc): return notification results

### DIFF
--- a/lua/typescript-tools/rpc.lua
+++ b/lua/typescript-tools/rpc.lua
@@ -29,7 +29,7 @@ function M.start(dispatchers)
       return request_router.route_request(tsserver_syntax, tsserver_semantic, method, ...)
     end,
     notify = function(...)
-      request_router.route_request(tsserver_syntax, tsserver_semantic, ...)
+      return request_router.route_request(tsserver_syntax, tsserver_semantic, ...)
     end,
     terminate = function()
       tsserver_syntax:terminate()


### PR DESCRIPTION
Fixes #156 

[`vim.lsp.rpc.notify()`](https://neovim.io/doc/user/lsp.html#vim.lsp.rpc.notify()) should return `true` when the notification was successfully sent. Without this, [this line](https://github.com/neovim/neovim/blob/6405fa4b117263b92f87b17150abd2d1c6ab5881/runtime/lua/vim/lsp.lua#L1583) is always `nil`, [`LspNotify` autocommands aren't executed](https://github.com/neovim/neovim/blob/6405fa4b117263b92f87b17150abd2d1c6ab5881/runtime/lua/vim/lsp.lua#L1587), and then [inlay hints aren't refreshed](https://github.com/neovim/neovim/blob/6405fa4b117263b92f87b17150abd2d1c6ab5881/runtime/lua/vim/lsp/inlay_hint.lua#L153).