### PR TITLE
feat: find tsserver from path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ bugs.
 - 🌍 Supports the nvim LSP plugin ecosystem
 - 🔀 Supports multiple instances of Tsserver
 - 💻 Supports both local and global installations of TypeScript
-- 🔨 Supports tsserver installed from [Mason](https://github.com/williamboman/mason.nvim)
+- 🔨 Supports `tsserver` installed from [Mason](https://github.com/williamboman/mason.nvim)
 - 💅 Provides out-of-the-box support for styled-components, which is not enabled by default
   (see Installation and [Configuration](#-styled-components-support))
 - ✨ Improved code refactor capabilities e.g. extracting to variable or function

--- a/lua/typescript-tools/tsserver_provider.lua
+++ b/lua/typescript-tools/tsserver_provider.lua
@@ -109,9 +109,7 @@ local function get_tsserver_from_mason()
   if vim.env.MASON then
     local tsserver_path = Path:new(vim.env.MASON, "packages", "typescript-language-server")
 
-    if
-      (plugin_config.tsserver_path or ""):find(tsserver_path, 1, true) and tsserver_path:exists()
-    then
+    if (plugin_config.tsserver_path or ""):find(tsserver_path, 1, true) then
       vim.schedule_wrap(vim.notify_once)(
         "[typescript-tools] We detected usage of `tsserver_path` to integrate with Mason. "
           .. "This integration is now built-in you can remove unnecessary code from your config.",

--- a/lua/typescript-tools/tsserver_provider.lua
+++ b/lua/typescript-tools/tsserver_provider.lua
@@ -133,9 +133,9 @@ function TsserverProvider:get_executable_path()
   end
 
   -- this will pick up an executable installed by mason if available
-  if not tsserver_exists(tsserver_path) and vim.fn.executable("tsserver") then
+  if not tsserver_exists(tsserver_path) and vim.fn.executable "tsserver" then
     local _ = log.trace() and log.trace("tsserver", tsserver_path:absolute(), "not exists.")
-    tsserver_path = vim.fn.exepath("tsserver")
+    tsserver_path = vim.fn.exepath "tsserver"
   end
 
   if not tsserver_exists(tsserver_path) then

--- a/lua/typescript-tools/tsserver_provider.lua
+++ b/lua/typescript-tools/tsserver_provider.lua
@@ -106,10 +106,11 @@ end
 
 ---@return Path|nil
 local function get_tsserver_from_mason()
-  if vim.env.MASON then
-    local tsserver_path = Path:new(vim.env.MASON, "packages", "typescript-language-server")
+  local MASON = os.getenv "MASON"
+  if MASON then
+    local tsserver_path = Path:new(MASON, "packages", "typescript-language-server")
 
-    if (plugin_config.tsserver_path or ""):find(tsserver_path, 1, true) then
+    if (plugin_config.tsserver_path or ""):find(tsserver_path:absolute(), 1, true) then
       vim.schedule_wrap(vim.notify_once)(
         "[typescript-tools] We detected usage of `tsserver_path` to integrate with Mason. "
           .. "This integration is now built-in you can remove unnecessary code from your config.",
@@ -154,7 +155,7 @@ function TsserverProvider:get_executable_path()
 
   if mason_tsserver and not tsserver_exists(tsserver_path) then
     local _ = log.trace() and log.trace("tsserver", tsserver_path:absolute(), "not exists.")
-    tsserver_path = mason_tsserver:join("typescript", "lib", "tsserver.js")
+    tsserver_path = mason_tsserver:joinpath("typescript", "lib", "tsserver.js")
   end
 
   if not tsserver_exists(tsserver_path) then

--- a/lua/typescript-tools/tsserver_provider.lua
+++ b/lua/typescript-tools/tsserver_provider.lua
@@ -104,32 +104,8 @@ function TsserverProvider.get_instance()
   return TsserverProvider.instance
 end
 
----@return Path|nil
-local function get_tsserver_from_mason()
-  local ok, mason_registry = pcall(require, "mason-registry")
-
-  if ok and mason_registry then
-    local tsserver_path =
-      mason_registry.get_package("typescript-language-server"):get_install_path()
-
-    if (plugin_config.tsserver_path or ""):find(tsserver_path, 1, true) then
-      vim.schedule_wrap(vim.notify_once)(
-        "[typescript-tools] We detected usage of `tsserver_path` to integrate with Mason. "
-          .. "This integration is now built-in you can remove unnecessary code from your config.",
-        vim.log.levels.WARN
-      )
-    end
-
-    return Path:new(tsserver_path, "node_modules")
-  end
-
-  return nil
-end
-
 ---@return Path
 function TsserverProvider:get_executable_path()
-  local mason_tsserver = get_tsserver_from_mason()
-
   if plugin_config.tsserver_path then
     local tsserver_path = Path:new(plugin_config.tsserver_path)
 
@@ -156,9 +132,10 @@ function TsserverProvider:get_executable_path()
     tsserver_path = self.global_install_path:joinpath("lib", "tsserver.js")
   end
 
-  if mason_tsserver and not tsserver_exists(tsserver_path) then
+  -- this will pick up an executable installed by mason if available
+  if not tsserver_exists(tsserver_path) and vim.fn.executable("tsserver") then
     local _ = log.trace() and log.trace("tsserver", tsserver_path:absolute(), "not exists.")
-    tsserver_path = mason_tsserver:joinpath("typescript", "lib", "tsserver.js")
+    tsserver_path = vim.fn.exepath("tsserver")
   end
 
   if not tsserver_exists(tsserver_path) then

--- a/lua/typescript-tools/tsserver_provider.lua
+++ b/lua/typescript-tools/tsserver_provider.lua
@@ -106,9 +106,9 @@ end
 
 ---@return Path|nil
 local function get_tsserver_from_mason()
-  local MASON = os.getenv "MASON"
-  if MASON then
-    local tsserver_path = Path:new(MASON, "packages", "typescript-language-server")
+  local mason_path = os.getenv "MASON"
+  if mason_path then
+    local tsserver_path = Path:new(mason_path, "packages", "typescript-language-server")
 
     if (plugin_config.tsserver_path or ""):find(tsserver_path:absolute(), 1, true) then
       vim.schedule_wrap(vim.notify_once)(


### PR DESCRIPTION
https://github.com/pmizio/typescript-tools.nvim/pull/152 introduced the ability to find `tsserver` based on `mason-registry`.
That approach is problematic because calling `require('mason-registry').get_package(...)` requires `require('mason-registry').refresh` to have been called first.
`mason` works by installing the LSPs into the path, unfortunately though, `tsserver` is just not available yet.
Once https://github.com/mason-org/mason-registry/pull/2845 goes through though, we can do `MasonInstall tsserver`, and voilla, no need to reach into the mason registry.
Leaving this as a draft until the registry PR goes in
@williamboman thanks for the help here!!!