### PR TITLE
fix(codelens): correct capability condition

### DIFF
--- a/lua/typescript-tools/capabilities.lua
+++ b/lua/typescript-tools/capabilities.lua
@@ -113,11 +113,9 @@ local function make_capabilities()
     documentRangeFormattingProvider = true,
     callHierarchyProvider = true,
     workspaceSymbolProvider = true,
-    codeLensProvider = (config.code_lens == config.code_lens_mode.off or not vim.treesitter)
-        and false
-      or {
-        resolveProvider = true,
-      },
+    codeLensProvider = config.code_lens ~= config.code_lens_mode.off and vim.treesitter and {
+      resolveProvider = true,
+    },
   }
 end
 


### PR DESCRIPTION
This boolean condition causes `resolveProvider` to always be true, since `(...) and false` is always false so the stuff on the right side of the `or` will always be used.