### PR TITLE
fix: `codelens.refresh` should be called only for supported files

### DIFF
--- a/lua/typescript-tools/autocommands/code_lens.lua
+++ b/lua/typescript-tools/autocommands/code_lens.lua
@@ -1,6 +1,7 @@
 local api = vim.api
 
 local common = require "typescript-tools.autocommands.common"
+local utils = require "typescript-tools.utils"
 
 local M = {}
 
@@ -13,6 +14,10 @@ function M.setup_code_lens_autocmds()
     api.nvim_create_autocmd({ "BufEnter", "InsertLeave", "CursorHold" }, {
       pattern = common.extensions_pattern,
       callback = function(e)
+        if not utils.get_typescript_client(e.buf) then
+          return
+        end
+
         ---@type string
         local file = e.file
 

--- a/lua/typescript-tools/autocommands/code_lens.lua
+++ b/lua/typescript-tools/autocommands/code_lens.lua
@@ -11,7 +11,7 @@ function M.setup_code_lens_autocmds()
     pcall(vim.lsp.codelens.refresh)
 
     api.nvim_create_autocmd({ "BufEnter", "InsertLeave", "CursorHold" }, {
-      pattern = M.extensions_pattern,
+      pattern = common.extensions_pattern,
       callback = function(e)
         ---@type string
         local file = e.file

--- a/lua/typescript-tools/autocommands/common.lua
+++ b/lua/typescript-tools/autocommands/common.lua
@@ -11,6 +11,7 @@ function M.create_lsp_attach_augcmd(callback, augroup)
   local initialized = false
 
   api.nvim_create_autocmd("LspAttach", {
+    pattern = M.extensions_pattern,
     callback = function(e)
       local client = vim.lsp.get_client_by_id(e.data.client_id)
 

--- a/lua/typescript-tools/utils.lua
+++ b/lua/typescript-tools/utils.lua
@@ -72,6 +72,7 @@ function M.is_nightly()
 end
 
 ---@param bufnr integer
+---@return lsp.Client|nil
 function M.get_typescript_client(bufnr)
   local get_clients = M.is_nightly() and vim.lsp.get_clients or vim.lsp.get_active_clients
   local clients = get_clients {


### PR DESCRIPTION
Should fix: https://github.com/pmizio/typescript-tools.nvim/issues/173