### PR TITLE
feat: find global tsserver from Nix store

### DIFF
--- a/lua/typescript-tools/tsserver_provider.lua
+++ b/lua/typescript-tools/tsserver_provider.lua
@@ -162,9 +162,10 @@ function TsserverProvider:get_executable_path()
     local _ = log.trace() and log.trace("tsserver", tsserver_path:absolute(), "not exists.")
   end
 
+-- INFO: to resolve tsserver in Nix store
   if not tsserver_exists(tsserver_path) then
     local _ = log.trace() and log.trace("tsserver", tsserver_path:absolute(), "not exists.")
-    tsserver_path = self.global_install_path:joinpath("bin", "tsserver")
+    tsserver_path = self.global_install_path:joinpath("lib", "node_modules","typescript","lib","tsserver.js")
   end
 
   -- INFO: if there is no local or global tsserver just error out

--- a/lua/typescript-tools/tsserver_provider.lua
+++ b/lua/typescript-tools/tsserver_provider.lua
@@ -162,6 +162,11 @@ function TsserverProvider:get_executable_path()
     local _ = log.trace() and log.trace("tsserver", tsserver_path:absolute(), "not exists.")
   end
 
+  if not tsserver_exists(tsserver_path) then
+    local _ = log.trace() and log.trace("tsserver", tsserver_path:absolute(), "not exists.")
+    tsserver_path = self.global_install_path:joinpath("bin", "tsserver")
+  end
+
   -- INFO: if there is no local or global tsserver just error out
   assert(
     tsserver_exists(tsserver_path),


### PR DESCRIPTION
Executable is found but errors pop up inside `Node` ...

Nix tsserver binary is 
```sh
#! /nix/store/lf0wpjrj8yx4gsmw2s3xfl58ixmqk8qa-bash-5.2-p15/bin/bash -e
exec "/nix/store/5l687mklyr9rhhbvvpvi93zv0zbbi4vg-nodejs-18.18.2/bin/node"  /nix/store/wrif36nqpxiw6f501ln2snyrwbd19k25-typescript-5.2.2/lib/node_modules/typescript/./bin/tsserver "$@" 

```
```
[ERROR][2023-11-16 15:43:26] ...ools/process.lua:184	"process"	"tsserver"	"stderr"	'/nix/store/wrif36nqpxiw6f501ln2snyrwbd19k25-typescript-5.2.2/bin/tsserver:2
exec "/nix/store/5l687mklyr9rhhbvvpvi93zv0zbbi4vg-nodejs-18.18.2/bin/node"  /nix/store/wrif36nqpxiw6f501ln2snyrwbd19k25-typescript-5.2.2/lib/node_modules/typescript/./bin/tsserver "$@" 
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

SyntaxError: Unexpected string
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1178:20)
    at Module._compile (node:internal/modules/cjs/loader:1220:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:86:12)
    at node:internal/main/run_main_module:23:47

Node.js v18.18.2
'
[ERROR][2023-11-16 15:43:26] ...ools/process.lua:184	"process"	"tsserver"	"stderr"	'/nix/store/wrif36nqpxiw6f501ln2snyrwbd19k25-typescript-5.2.2/bin/tsserver:2
exec "/nix/store/5l687mklyr9rhhbvvpvi93zv0zbbi4vg-nodejs-18.18.2/bin/node"  /nix/store/wrif36nqpxiw6f501ln2snyrwbd19k25-typescript-5.2.2/lib/node_modules/typescript/./bin/tsserver "$@" 
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

SyntaxError: Unexpected string
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1178:20)
    at Module._compile (node:internal/modules/cjs/loader:1220:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:86:12)
    at node:internal/main/run_main_module:23:47

Node.js v18.18.2
'


```