### PR TITLE
fix: fix plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ require("typescript-tools").setup {
     -- be too much this option reduce count of them by removing member references from lenses
     disable_member_code_lens = true,
     -- JSXCloseTag
-    -- WARNING: it is disabled by default (maybe you configuration or distro already uses nvim-auto-tag,
+    -- WARNING: it is disabled by default (maybe you configuration or distro already uses nvim-ts-autotag,
     -- that maybe have a conflict if enable this feature. )
     jsx_close_tag = {
         enable = false,


### PR DESCRIPTION
Looking at https://github.com/pmizio/typescript-tools.nvim/issues/169, does it refer to [nvim-ts-autotag](https://github.com/windwp/nvim-ts-autotag)?