### PR TITLE
fix: use buffer number instead of a boolean to limit on_attach calls

### DIFF
--- a/lua/typescript-tools/autocommands/init.lua
+++ b/lua/typescript-tools/autocommands/init.lua
@@ -2,12 +2,15 @@ local diagnostics = require "typescript-tools.autocommands.diagnostics"
 local code_lens = require "typescript-tools.autocommands.code_lens"
 local config = require "typescript-tools.config"
 local jsx_close_tag = require "typescript-tools.autocommands.jsx_close_tag"
+local on_attach = require "typescript-tools.autocommands.on_attach"
 
 local M = {}
 
 ---@param dispatchers Dispatchers
 function M.setup_autocommands(dispatchers)
   diagnostics.setup_diagnostic_autocmds(dispatchers)
+
+  on_attach.setup_on_attach_autocmds()
 
   if config.code_lens ~= config.code_lens_mode.off then
     code_lens.setup_code_lens_autocmds()

--- a/lua/typescript-tools/autocommands/on_attach.lua
+++ b/lua/typescript-tools/autocommands/on_attach.lua
@@ -1,0 +1,18 @@
+local api = vim.api
+
+local M = {}
+
+M.buf_map = {}
+
+function M.setup_on_attach_autocmds()
+  local augroup = api.nvim_create_augroup("TypescriptToolsOnAttachGroup", { clear = true })
+  api.nvim_create_autocmd("BufDelete", {
+    callback = function(args)
+      local buf_key = tostring(args.buf)
+      M.buf_map[buf_key] = false
+    end,
+    group = augroup,
+  })
+end
+
+return M

--- a/lua/typescript-tools/init.lua
+++ b/lua/typescript-tools/init.lua
@@ -48,16 +48,14 @@ function M.setup(config)
   -- I prefer it here than in huge file tsserver.lua
   -- Rationale: `on_attach` is called based on response from `configure` request and because we
   -- have two servers nvim get also two responses
-  local on_attach_called = false
+  local last_bufnr = -1
   local config_on_attach = config.on_attach
 
-  local function on_attach(...)
-    if on_attach_called then
-      return
+  local function on_attach(client, bufnr)
+    if bufnr ~= last_bufnr then
+      last_bufnr = bufnr
+      config_on_attach(client, bufnr)
     end
-
-    on_attach_called = true
-    config_on_attach(...)
   end
 
   if config.on_attach then

--- a/lua/typescript-tools/init.lua
+++ b/lua/typescript-tools/init.lua
@@ -3,6 +3,7 @@ local configs = require "lspconfig.configs"
 local util = require "lspconfig.util"
 local rpc = require "typescript-tools.rpc"
 local plugin_config = require "typescript-tools.config"
+local on_attach_aucmd = require "typescript-tools.autocommands.on_attach"
 
 local M = {}
 
@@ -48,10 +49,10 @@ function M.setup(config)
   -- I prefer it here than in huge file tsserver.lua
   -- Rationale: `on_attach` is called based on response from `configure` request and because we
   -- have two servers nvim get also two responses
-  local buf_map = {}
+  local buf_map = on_attach_aucmd.buf_map
   local config_on_attach = config.on_attach
 
-  local function on_attach(client, bufnr)
+  local function wrapped_on_attach(client, bufnr)
     local buf_key = tostring(bufnr)
     if buf_map[buf_key] then
       return
@@ -60,17 +61,8 @@ function M.setup(config)
     config_on_attach(client, bufnr)
   end
 
-  local augroup = vim.api.nvim_create_augroup("TypescriptToolsOnAttachGroup", { clear = true })
-  vim.api.nvim_create_autocmd("BufDelete", {
-    callback = function(args)
-      local buf_key = tostring(args.buf)
-      buf_map[buf_key] = false
-    end,
-    group = augroup,
-  })
-
   if config.on_attach then
-    config.on_attach = on_attach
+    config.on_attach = wrapped_on_attach
   end
 
   lspconfig[plugin_config.plugin_name].setup(config)


### PR DESCRIPTION
as mentioned in the comments of PR #213, the use of a boolean prevents `on_attach` from being called when a new buffer is opened. I tried implementing the same idea of limiting the `on_attach` calls but with buffer number instead.