### PR TITLE
fix: Respect bufnr with codelens parser

### DIFF
--- a/lua/typescript-tools/protocol/text_document/code_lens/init.lua
+++ b/lua/typescript-tools/protocol/text_document/code_lens/init.lua
@@ -36,7 +36,8 @@ end
 ---@type TsserverProtocolHandler
 function M.handler(request, _, params)
   local text_document = params.textDocument
-  local ok, parser = pcall(ts.get_parser)
+  local bufnr = vim.uri_to_bufnr(text_document.uri)
+  local ok, parser = pcall(ts.get_parser, bufnr)
 
   if not ok then
     vim.notify_once(


### PR DESCRIPTION
In `textDocument/codeLens` handler, `get_parser` has no argument, so it processes with the current buffer content regardless of the textDocument content.

Fixed to respect bufnr as well as `convert_nodes_to_response`.