### PR TITLE
fix: deprecated warnings

### DIFF
--- a/lua/typescript-tools/api.lua
+++ b/lua/typescript-tools/api.lua
@@ -141,7 +141,7 @@ end
 ---@param callback fun(params: table, result: table)|nil
 function M.request_diagnostics(callback)
   local text_document = vim.lsp.util.make_text_document_params()
-  local client = vim.lsp.get_active_clients {
+  local client = utils.get_clients {
     name = plugin_config.plugin_name,
     bufnr = vim.uri_to_bufnr(text_document.uri),
   }
@@ -212,7 +212,7 @@ end
 ---
 ---@param codes integer[]
 function M.filter_diagnostics(codes)
-  vim.tbl_add_reverse_lookup(codes)
+  utils.add_reverse_lookup(codes)
   return function(err, res, ctx, config)
     local filtered = {}
     for _, diag in ipairs(res.diagnostics) do

--- a/lua/typescript-tools/protocol/module_mapper.lua
+++ b/lua/typescript-tools/protocol/module_mapper.lua
@@ -1,4 +1,5 @@
 local c = require "typescript-tools.protocol.constants"
+local utils = require "typescript-tools.utils"
 
 local remapped_methods = {
   [c.LspMethods.CompletionResolve] = "text_document.completion.resolve",
@@ -18,7 +19,7 @@ local remapped_methods = {
 }
 
 local noop_methods = { c.LspMethods.DidSave }
-vim.tbl_add_reverse_lookup(noop_methods)
+utils.add_reverse_lookup(noop_methods)
 
 local M = {}
 

--- a/lua/typescript-tools/protocol/text_document/custom_diagnostic.lua
+++ b/lua/typescript-tools/protocol/text_document/custom_diagnostic.lua
@@ -31,7 +31,7 @@ local stylecheck_diagnostics = {
   -- not all code paths return a value
   7030,
 }
-vim.tbl_add_reverse_lookup(stylecheck_diagnostics)
+utils.add_reverse_lookup(stylecheck_diagnostics)
 
 --- @param diagnostic table
 --- @return DiagnosticSeverity
@@ -83,7 +83,7 @@ end
 
 --- @return string[]
 local function get_attached_buffers()
-  local client = vim.lsp.get_active_clients({ name = plugin_config.plugin_name })[1]
+  local client = utils.get_clients({ name = plugin_config.plugin_name })[1]
 
   if client then
     local attached_bufs = {}

--- a/lua/typescript-tools/protocol/text_document/prepare_call_hierarchy.lua
+++ b/lua/typescript-tools/protocol/text_document/prepare_call_hierarchy.lua
@@ -3,6 +3,8 @@ local utils = require "typescript-tools.protocol.utils"
 
 local M = {}
 
+local islist = vim.islist or vim.tbl_islist
+
 ---@type TsserverProtocolHandler
 function M.handler(request, response, params)
   local text_document = params.textDocument
@@ -18,7 +20,7 @@ function M.handler(request, response, params)
   -- tsserver protocol reference:
   -- https://github.com/microsoft/TypeScript/blob/503604c884bd0557c851b11b699ef98cdb65b93b/lib/protocol.d.ts#L2584
   local body = coroutine.yield()
-  body = vim.tbl_islist(body) and body or { body }
+  body = islist(body) and body or { body }
 
   response(vim.tbl_map(function(it)
     return utils.convert_tsserver_call_hierarchy_item_to_lsp(it)

--- a/lua/typescript-tools/utils.lua
+++ b/lua/typescript-tools/utils.lua
@@ -71,11 +71,15 @@ function M.is_nightly()
   return type(v) ~= "boolean" and v ~= nil or v
 end
 
+function M.get_clients(filter)
+  local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  return get_clients(filter)
+end
+
 ---@param bufnr integer
 ---@return lsp.Client|nil
 function M.get_typescript_client(bufnr)
-  local get_clients = M.is_nightly() and vim.lsp.get_clients or vim.lsp.get_active_clients
-  local clients = get_clients {
+  local clients = M.get_clients {
     name = plugin_config.plugin_name,
     bufnr = bufnr,
   }
@@ -102,6 +106,15 @@ function M.list_contains(list, value)
   end
 
   return false
+end
+
+--- @param tbl table
+function M.add_reverse_lookup(tbl)
+  local keys = vim.tbl_keys(tbl)
+  for _, k in ipairs(keys) do
+    local v = tbl[k]
+    tbl[v] = k
+  end
 end
 
 return M

--- a/tests/utils.lua
+++ b/tests/utils.lua
@@ -84,7 +84,7 @@ end
 ---@param capability string
 ---@return boolean
 function M.supports_capability(capability)
-  return not not vim.lsp.get_active_clients({
+  return not not vim.lsp.get_clients({
     name = require("typescript-tools.config").plugin_name,
   })[1].server_capabilities[capability]
 end


### PR DESCRIPTION
Fix: https://github.com/pmizio/typescript-tools.nvim/issues/266

This PR will fix not to use the following deprecated api.

- `vim.tbl_add_reverse_lookup()`
- `vim.tbl_islist()`
- `vim.lsp.get_active_clients()`

📝 https://neovim.io/doc/user/deprecated.html#deprecated-0.10
