### PR TITLE
Fix textDocument/codeLens error when a non-TS file is open

### DIFF
--- a/lua/typescript-tools/autocommands/code_lens.lua
+++ b/lua/typescript-tools/autocommands/code_lens.lua
@@ -25,7 +25,7 @@ function M.setup_code_lens_autocmds()
           return
         end
 
-        pcall(vim.lsp.codelens.refresh)
+        pcall(vim.lsp.codelens.refresh, { bufnr = e.buf })
       end,
       group = augroup,
     })


### PR DESCRIPTION
Based on @Chaitanyabsprip comment in #280.

Fixes:
- #280 
- #274 
- #173 

Related PRs:
- #246 
- #177 

---

On a side note, I couldn't make tests work after cloning the repo, here's the output I get:

```
$ make test
nvim --headless --noplugin -u tests/init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/init.lua'}"
Installing nvim-lua/plenary.nvim
Installing neovim/nvim-lspconfig
Installing nvim-treesitter/nvim-treesitter
Downloading tree-sitter-typescript...
Creating temporary directory
Extracting tree-sitter-typescript...
Compiling...
Treesitter parser for typescript has been installed
Starting...Scheduling: tests//requests_spec.lua
Scheduling: tests//editor_spec.lua
make: *** [test] Error 1
```