### PR TITLE
fix: duplicated s on member completion

### DIFF
--- a/lua/typescript-tools/protocol/text_document/completion/init.lua
+++ b/lua/typescript-tools/protocol/text_document/completion/init.lua
@@ -25,7 +25,7 @@ local function calculate_member_completion_context(body, params)
   if body.isMemberCompletion then
     local line =
       vim.api.nvim_buf_get_lines(0, params.position.line, params.position.line + 1, false)[1]
-    local dotAccessText = string.match(line:sub(1, params.position.character), "%??%.s*$") or nil
+    local dotAccessText = string.match(line:sub(1, params.position.character), "%??%.$") or nil
     if dotAccessText then
       local startPosition = {
         line = params.position.line,


### PR DESCRIPTION
If member completion is triggered with one or more consecutive `s`'s after `.`, the `s`'s will not be deleted, resulting in an incorrect completion.
However, I don't know why the `s*` was included in the pattern, so if there was a good reason for it, please let me know.
Thanks for the great plugin!

https://github.com/user-attachments/assets/cddeb23a-6dcd-4b7d-b337-6176cbe3a686

