### PR TITLE
fix: use vim.fs.normalize instead of using a helper from lspconfig

### DIFF
--- a/lua/typescript-tools/tsserver_provider.lua
+++ b/lua/typescript-tools/tsserver_provider.lua
@@ -64,7 +64,7 @@ function TsserverProvider.new(on_loaded)
 
   assert(util.bufname_valid(bufname), "Invalid buffer name!")
 
-  local sanitized_bufname = util.path.sanitize(bufname)
+  local sanitized_bufname = vim.fs.normalize(bufname)
 
   self.root_dir = Path:new(config.get_root_dir(sanitized_bufname, bufnr))
   self.npm_local_path = find_deep_node_modules_ancestor(sanitized_bufname):joinpath "node_modules"


### PR DESCRIPTION
fixes: #317 

Lsp-config helpers dropped the method `sanitize` in favor of the now provided `vim.fs.normalize`.

Here is the [PR](https://github.com/neovim/nvim-lspconfig/commit/d651732cecfc77be1b3727512bec0438c22410d1#diff-9e30880c16142e9d50a64563fd1260aa9f851b782dd74678163e151b93878568L219) where the function was removed. 

