### PR TITLE
feat(tsserver plugins): Allow for path in tsserver_plugins

### DIFF
--- a/lua/typescript-tools/config.lua
+++ b/lua/typescript-tools/config.lua
@@ -4,7 +4,7 @@
 ---@field tsserver_logs string
 ---@field publish_diagnostic_on publish_diagnostic_mode
 ---@field tsserver_path string|nil
----@field tsserver_plugins string[]
+---@field tsserver_plugins (string|{name: string, path: string})[]
 ---@field tsserver_format_options table|fun(filetype: string): table
 ---@field tsserver_file_preferences table|fun(filetype: string): table
 ---@field tsserver_max_memory number|"auto"


### PR DESCRIPTION
maybe closed #287

# what i did

add a another way to add `tsserver_plugins`:
```lua
{
	name = "xxx",
	path = "xxx",
}
```
and can be mixed with string.

# example:

```lua
local mason_path = vim.fn.stdpath "data" .. "/mason/packages/"
local ft = { "typescript", "javascript", "javascriptreact", "typescriptreact", "vue", "markdown.mdx" }

return {
    "pmizio/typescript-tools.nvim",
    ft = ft,
    dependencies = "nvim-lua/plenary.nvim",
    opts = {
        filetypes = ft,
        settings = {
            tsserver_plugins = {
                "@vue/typescript-plugin",        
                {
                    name = "@mdxjs/typescript-plugin",
                    path = mason_path .. "mdx-analyzer" .. "/node_modules/@mdx/language-server",
                },
            },
        },
    },
}
```