### PR TITLE
Fix `code_lens` with correct iteration over query match nodes

### DIFF
--- a/lua/typescript-tools/protocol/text_document/code_lens/init.lua
+++ b/lua/typescript-tools/protocol/text_document/code_lens/init.lua
@@ -12,6 +12,11 @@ local function convert_nodes_to_response(tree, query, text_document, lenses, imp
   for _, match in query:iter_matches(tree:root(), vim.uri_to_bufnr(text_document.uri)) do
     for id, nodes in pairs(match) do
       local name = query.captures[id]
+
+      if type(nodes.range) == "function" then
+        nodes = { nodes }
+      end
+
       for _, node in ipairs(nodes) do
         local start_row, start_col, end_row, end_col = node:range()
 

--- a/lua/typescript-tools/protocol/text_document/code_lens/init.lua
+++ b/lua/typescript-tools/protocol/text_document/code_lens/init.lua
@@ -10,25 +10,27 @@ local M = {}
 ---@param implementations boolean|nil
 local function convert_nodes_to_response(tree, query, text_document, lenses, implementations)
   for _, match in query:iter_matches(tree:root(), vim.uri_to_bufnr(text_document.uri)) do
-    for id, node in pairs(match) do
+    for id, nodes in pairs(match) do
       local name = query.captures[id]
-      local start_row, start_col, end_row, end_col = node:range()
+      for _, node in ipairs(nodes) do
+        local start_row, start_col, end_row, end_col = node:range()
 
-      if config.disable_member_code_lens and name == "member" then
-        goto continue
+        if config.disable_member_code_lens and name == "member" then
+          goto continue
+        end
+
+        table.insert(lenses, {
+          range = {
+            start = { line = start_row, character = start_col },
+            ["end"] = { line = end_row, character = end_col },
+          },
+          data = {
+            textDocument = text_document,
+            implementations = implementations,
+          },
+        })
+        ::continue::
       end
-
-      table.insert(lenses, {
-        range = {
-          start = { line = start_row, character = start_col },
-          ["end"] = { line = end_row, character = end_col },
-        },
-        data = {
-          textDocument = text_document,
-          implementations = implementations,
-        },
-      })
-      ::continue::
     end
   end
 end


### PR DESCRIPTION
Neovim 0.11 changed `query:iter_matches` to return a list of nodes per capture instead of a single `TSNode`. `convert_nodes_to_response` didn’t account for this, causing it to attempt `.range()` on a table, leading to runtime errors.