### PR TITLE
fix: deprecated table argument for `vim.validate`

### DIFF
--- a/lua/typescript-tools/config.lua
+++ b/lua/typescript-tools/config.lua
@@ -94,7 +94,7 @@ M.plugin_name = "typescript-tools"
 
 ---@param settings table
 function M.load_settings(settings)
-  vim.validate {
+  local table_to_validate = {
     settings = { settings, "table", true },
     ["settings.separate_diagnostic_server"] = {
       settings.separate_diagnostic_server,
@@ -140,6 +140,9 @@ function M.load_settings(settings)
     ["settings.disable_member_code_lens"] = { settings.disable_member_code_lens, "boolean", true },
     ["settings.jsx_close_tag"] = { settings.jsx_close_tag, "table", true },
   }
+  for name, validate_config in pairs(table_to_validate) do
+    vim.validate(name, validate_config[1], validate_config[2], validate_config[3])
+  end
 
   __store = vim.tbl_deep_extend("force", __store, settings)
 

--- a/lua/typescript-tools/config.lua
+++ b/lua/typescript-tools/config.lua
@@ -94,55 +94,62 @@ M.plugin_name = "typescript-tools"
 
 ---@param settings table
 function M.load_settings(settings)
-  local table_to_validate = {
-    settings = { settings, "table", true },
-    ["settings.separate_diagnostic_server"] = {
-      settings.separate_diagnostic_server,
-      "boolean",
-      true,
-    },
-    ["settings.publish_diagnostic_on"] = { settings.publish_diagnostic_on, "string", true },
-    ["settings.tsserver_path"] = { settings.tsserver_path, "string", true },
-    ["settings.tsserver_plugins"] = { settings.tsserver_plugins, "table", true },
-    ["settings.tsserver_format_options"] = {
-      settings.tsserver_format_options,
-      { "table", "function" },
-      true,
-    },
-    ["settings.tsserver_file_preferences"] = {
-      settings.tsserver_file_preferences,
-      { "table", "function" },
-      true,
-    },
-    ["settings.tsserver_logs"] = { settings.tsserver_logs, "string", true },
-    ["settings.tsserver_max_memory"] = {
-      settings.tsserver_max_memory,
-      { "number", "string" },
-      true,
-    },
-    ["settings.tsserver_locale"] = {
-      settings.tsserver_locale,
-      "string",
-      true,
-    },
-    ["settings.complete_function_calls"] = { settings.complete_function_calls, "boolean", true },
-    ["settings.expose_as_code_action"] = {
-      settings.expose_as_code_action,
-      { "table", "string" },
-      true,
-    },
-    ["settings.include_completions_with_insert_text"] = {
-      settings.include_completions_with_insert_text,
-      "boolean",
-      true,
-    },
-    ["settings.code_lens"] = { settings.code_lens, "string", true },
-    ["settings.disable_member_code_lens"] = { settings.disable_member_code_lens, "boolean", true },
-    ["settings.jsx_close_tag"] = { settings.jsx_close_tag, "table", true },
-  }
-  for name, validate_config in pairs(table_to_validate) do
-    vim.validate(name, validate_config[1], validate_config[2], validate_config[3])
-  end
+  vim.validate("settings", settings, "table", true)
+  vim.validate(
+    "settings.separate_diagnostic_server",
+    settings.separate_diagnostic_server,
+    "boolean",
+    true
+  )
+  vim.validate("settings.publish_diagnostic_on", settings.publish_diagnostic_on, "string", true)
+  vim.validate("settings.tsserver_path", settings.tsserver_path, "string", true)
+  vim.validate("settings.tsserver_plugins", settings.tsserver_plugins, "table", true)
+  vim.validate(
+    "settings.tsserver_format_options",
+    settings.tsserver_format_options,
+    { "table", "function" },
+    true
+  )
+  vim.validate(
+    "settings.tsserver_file_preferences",
+    settings.tsserver_file_preferences,
+    { "table", "function" },
+    true
+  )
+  vim.validate("settings.tsserver_logs", settings.tsserver_logs, "string", true)
+  vim.validate(
+    "settings.tsserver_max_memory",
+    settings.tsserver_max_memory,
+    { "number", "string" },
+    true
+  )
+  vim.validate("settings.tsserver_locale", settings.tsserver_locale, "string", true)
+  vim.validate(
+    "settings.complete_function_calls",
+    settings.complete_function_calls,
+    "boolean",
+    true
+  )
+  vim.validate(
+    "settings.expose_as_code_action",
+    settings.expose_as_code_action,
+    { "table", "string" },
+    true
+  )
+  vim.validate(
+    "settings.include_completions_with_insert_text",
+    settings.include_completions_with_insert_text,
+    "boolean",
+    true
+  )
+  vim.validate("settings.code_lens", settings.code_lens, "string", true)
+  vim.validate(
+    "settings.disable_member_code_lens",
+    settings.disable_member_code_lens,
+    "boolean",
+    true
+  )
+  vim.validate("settings.jsx_close_tag", settings.jsx_close_tag, "table", true)
 
   __store = vim.tbl_deep_extend("force", __store, settings)
 


### PR DESCRIPTION
This PR fixes the deprecated use of the table argument for `vim.validate`. The table argument got deprecated in neovim 0.11 (https://github.com/neovim/neovim/blob/fece4897940896f487559b955e4f8f76d48f299c/runtime/doc/deprecated.txt#L95) and using individual `vim.validate` calls to validate multiple values is recommended now.

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/cdda0457-bc7c-47ff-9ea2-dc69eaaf616e" />


This PR has 2 commits:
1. A minimal change that still leverages the table of values to validate and re-implements the previous behavior by calling `vim.validate` in a loop. It has a very small diff
2. Avoids using the table altogether. Refactors the code to call `vim.valdiate` for each value to validate, without the loop.

Feel free to drop the 2nd one if you think the 1st one is good enough and having a single table of values to validate is convenient.

By the way, thanks for this awesome plugin. I was just listening to [the most recent Allegro Tech podcast](https://open.spotify.com/episode/7DqG25VeC0HKL1T0OL6xaX) and I immediately recognized @KostkaBrukowa as being one of the maintainers of this repository when he said his GitHub username at the end 😄 