### PR TITLE
fix: gracefully handle `handlers`  errors and fix documentHighlight and hover errors

### DIFF
--- a/lua/typescript-tools/protocol/text_document/document_highlight.lua
+++ b/lua/typescript-tools/protocol/text_document/document_highlight.lua
@@ -30,6 +30,7 @@ function M.handler(request, response, params)
   -- https://github.com/microsoft/TypeScript/blob/8a1b85880f89c9cff606c5844e8883e5f483c7db/lib/protocol.d.ts#L844
   if not body[1] then
     response(nil)
+    return
   end
 
   response(vim.tbl_map(function(item)

--- a/lua/typescript-tools/protocol/text_document/document_symbol.lua
+++ b/lua/typescript-tools/protocol/text_document/document_symbol.lua
@@ -40,8 +40,9 @@ function M.handler(request, response, params)
 
   -- tsserver protocol reference:
   -- https://github.com/microsoft/TypeScript/blob/8a1b85880f89c9cff606c5844e8883e5f483c7db/lib/protocol.d.ts#L2561
-  if #body.childItems == 0 then
+  if not body.childItems or #body.childItems == 0 then
     response(nil)
+    return
   end
 
   response(vim.tbl_map(map_document_symbol, remove_aliases(body.childItems)))

--- a/lua/typescript-tools/protocol/text_document/hover.lua
+++ b/lua/typescript-tools/protocol/text_document/hover.lua
@@ -17,6 +17,11 @@ function M.handler(request, response, params)
 
   local body = coroutine.yield()
 
+  if body.success == false then
+    response(nil)
+    return
+  end
+
   local contents = {
     utils.tsserver_docs_to_plain_text(body.documentation),
     utils.tsserver_make_tags(body.tags),

--- a/lua/typescript-tools/protocol/text_document/signature_help.lua
+++ b/lua/typescript-tools/protocol/text_document/signature_help.lua
@@ -101,6 +101,11 @@ function M.handler(request, response, params)
 
   local body = coroutine.yield()
 
+  if body.success == false then
+    response(nil)
+    return
+  end
+
   -- tsserver protocol reference:
   -- https://github.com/microsoft/TypeScript/blob/96894db6cb5b7af6857b4d0c7f70f7d8ac782d51/lib/protocol.d.ts#L1980
   response {


### PR DESCRIPTION
Fixes #321

The errors from the coroutines used to execute the handlers where previously ignored, this PR makes them noisy and writes them to the general lsp log with a full stacktrace to allow users to give better error reports.

This also surfaced 2 errors in my short tests, a missing early return for the documentHighlight handler and a similar error for the hover handler (that was the cause for #321). Both errors are fixed now.