### PR TITLE
fix: send empty response if code_action/resolve fails

### DIFF
--- a/lua/typescript-tools/protocol/text_document/code_action/resolve.lua
+++ b/lua/typescript-tools/protocol/text_document/code_action/resolve.lua
@@ -48,6 +48,14 @@ function M.handler(request, response, params)
 
   local body = coroutine.yield()
 
+  -- TODO: I'm getting an error response (success = false) for the `Move to
+  -- a new File` code action with the command `getEditsForRefactor`. Look into
+  -- if it's working as expected
+  if body.success == false then
+    response(nil)
+    return
+  end
+
   -- tsserver protocol reference:
   -- OrganizeImports:
   -- https://github.com/microsoft/TypeScript/blob/c18791ccf165672df3b55f5bdd4a8655f33be26c/lib/protocol.d.ts#L508


### PR DESCRIPTION
Fixes an error similar to the ones found on #346, this is what `:LspLog` contained

```log
[ERROR][2025-04-22 11:36:06] ...ols/tsserver.lua:104	"tsserver"	"Unexpected error while handling response: "	"codeAction/resolve"
[ERROR][2025-04-22 11:36:06] ...ols/tsserver.lua:105	"tsserver"	"...cript-tools.nvim/lua/typescript-tools/protocol/utils.lua:135: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
	[C]: in function 'ipairs'
	...cript-tools.nvim/lua/typescript-tools/protocol/utils.lua:135: in function 'get_edits'
	...ipt-tools/protocol/text_document/code_action/resolve.lua:60: in function <...ipt-tools/protocol/text_document/code_action/resolve.lua:18>"
```

The response that caused the error looks like

```lua
M.handler body: {
  command = "getEditsForRefactor",
  message = "...", -- for readability, instead of putting the whole message in here, I put it below after formatting it
  request_seq = 64,
  seq = 0,
  success = false,
  type = "response"
}
```

the formatted `message` is

```
Error processing request. Debug Failure. False expression: Expected symbol to be a module
Error: Debug Failure. False expression: Expected symbol to be a module
    at Object.addImportForModuleSymbol (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:156990:11)
    at /home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:146715:19
    at Map.forEach (<anonymous>)
    at addTargetFileImports (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:146708:17)
    at getNewStatementsAndRemoveFromOldFile (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:145939:3)
    at doChange4 (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:146935:3)
    at /home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:146924:77
    at _ChangeTracker.with (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:177632:5)
    at Object.getRefactorEditsToMoveToNewFile [as getEditsForAction] (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:146924:60)
    at Object.getEditsForRefactor (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:145029:31)
    at Object.getEditsForRefactor2 [as getEditsForRefactor] (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:152529:32)
    at IOSession.getEditsForRefactor (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:194809:49)
    at getEditsForRefactor (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:192960:43)
    at /home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:195231:15
    at IOSession.executeWithRequestId (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:195220:14)
    at IOSession.executeCommand (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:195229:29)
    at IOSession.onMessage (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/typescript.js:195277:68)
    at Interface.<anonymous> (/home/luis/Documentos/work/testing-poc/node_modules/typescript/lib/_tsserver.js:501:14)
    at Interface.emit (node:events:518:28)
    at[_onLine] [as _onLine] (node:internal/readline/interface:415:12)
    at [_normalWrite] [as _normalWrite] (node:internal/readline/interface:609:22)
    at Socket.ondata (node:internal/readline/interface:242:23)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:189:23)
```

This may be a temporary solution, because I'm not sure if this behavior is expected or not, so I left a `TODO` in the code mentioning details that lead to this error being triggered in order for it to be checked in the future.