### PR TITLE
Clarify auto setting behavior thanks to issue #304

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ require("typescript-tools").setup {
     -- (see 💅 `styled-components` support section)
     tsserver_plugins = {},
     -- this value is passed to: https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
-    -- memory limit in megabytes or "auto"(basically no limit)
+    -- memory limit in megabytes or "auto" (despite its name, will use the default node runtime memory settings)
     tsserver_max_memory = "auto",
     -- described below
     tsserver_format_options = {},


### PR DESCRIPTION
I was very confused why "auto" was not working the way I expected it to which caused a lot of confusion why I was receiving ton of node heap allocation limit errors.

The explanation here points out the documentation is misleading: https://github.com/pmizio/typescript-tools.nvim/issues/304#issuecomment-2457230327

Updating the docs to prevent future confusion.