### PR TITLE
fix: register user_commands with LspAttach augroup instead of ftplugin

### DIFF
--- a/ftplugin/javascript.lua
+++ b/ftplugin/javascript.lua
@@ -1,1 +1,0 @@
-require("typescript-tools.user_commands").setup_user_commands()

--- a/ftplugin/javascriptreact.lua
+++ b/ftplugin/javascriptreact.lua
@@ -1,1 +1,0 @@
-require("typescript-tools.user_commands").setup_user_commands()

--- a/ftplugin/typescript.lua
+++ b/ftplugin/typescript.lua
@@ -1,1 +1,0 @@
-require("typescript-tools.user_commands").setup_user_commands()

--- a/ftplugin/typescriptreact.lua
+++ b/ftplugin/typescriptreact.lua
@@ -1,1 +1,0 @@
-require("typescript-tools.user_commands").setup_user_commands()

--- a/lua/typescript-tools/autocommands/init.lua
+++ b/lua/typescript-tools/autocommands/init.lua
@@ -2,6 +2,7 @@ local diagnostics = require "typescript-tools.autocommands.diagnostics"
 local code_lens = require "typescript-tools.autocommands.code_lens"
 local config = require "typescript-tools.config"
 local jsx_close_tag = require "typescript-tools.autocommands.jsx_close_tag"
+local user_commands = require "typescript-tools.autocommands.user_commands"
 
 local M = {}
 
@@ -16,6 +17,8 @@ function M.setup_autocommands(dispatchers)
   if config.jsx_close_tag.enable then
     jsx_close_tag.setup_jsx_close_tag_autocmds()
   end
+
+  user_commands.autosetup_user_commands()
 end
 
 return M

--- a/lua/typescript-tools/autocommands/user_commands.lua
+++ b/lua/typescript-tools/autocommands/user_commands.lua
@@ -1,0 +1,14 @@
+local api = vim.api
+local common = require "typescript-tools.autocommands.common"
+
+local M = {}
+
+function M.autosetup_user_commands()
+  local augroup = api.nvim_create_augroup("TypescriptToolsUserCommandsGroup", { clear = true })
+
+  common.create_lsp_attach_augcmd(function()
+    require("typescript-tools.user_commands").setup_user_commands()
+  end, augroup)
+end
+
+return M


### PR DESCRIPTION
My problem:

When opening a .vue file the user commands don't get registered. Solutions:
1) Open a .ts file first and then continue with working in .vue files.
2) This PR

Also what do you think about changing the `create_lsp_attach_augcmd` in `autocommands.common` to use the filetypes specified in `lspconfig.configs` instead of custom matching the extensions? This could then be easily configurable.