### PR TITLE
feat: add diagnostics toggle

### DIFF
--- a/lua/typescript-tools/autocommands/init.lua
+++ b/lua/typescript-tools/autocommands/init.lua
@@ -7,7 +7,9 @@ local M = {}
 
 ---@param dispatchers Dispatchers
 function M.setup_autocommands(dispatchers)
-  diagnostics.setup_diagnostic_autocmds(dispatchers)
+  if config.diagnostics then
+    diagnostics.setup_diagnostic_autocmds(dispatchers)
+  end
 
   if config.code_lens ~= config.code_lens_mode.off then
     code_lens.setup_code_lens_autocmds()

--- a/lua/typescript-tools/config.lua
+++ b/lua/typescript-tools/config.lua
@@ -14,6 +14,7 @@
 ---@field include_completions_with_insert_text boolean
 ---@field code_lens code_lens_mode
 ---@field jsx_close_tag { enable: boolean, filetypes: string[] }
+---@field diagnostics boolean
 ---@field disable_member_code_lens boolean
 local M = {}
 local __store = {}
@@ -138,6 +139,7 @@ function M.load_settings(settings)
     },
     ["settings.code_lens"] = { settings.code_lens, "string", true },
     ["settings.disable_member_code_lens"] = { settings.disable_member_code_lens, "boolean", true },
+    ["settings.diagnostics"] = { settings.diagnostics, "boolean", true },
     ["settings.jsx_close_tag"] = { settings.jsx_close_tag, "table", true },
   }
 
@@ -210,6 +212,10 @@ function M.load_settings(settings)
 
   if settings.jsx_close_tag and not settings.jsx_close_tag.filetypes then
     __store.jsx_close_tag.filetypes = default_jsx_filetypes
+  end
+
+  if type(settings.diagnostics) == "nil" then
+    __store.diagnostics = true
   end
 end
 


### PR DESCRIPTION
Hi!
I’ve just started trying out typescript-tools, and I really like it so far — great work!

I’m going to try using nvim-lint with eslint_d for diagnostics. If that covers all my needs, I’ll disable tsserver’s built-in diagnostics to make both tsserver and typescript-tools run more lightly.

Maybe you could point out any potential pitfalls with this approach?