### PR TITLE
feat: migrate to native Neovim LSP APIs (nvim 0.11+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ In summary, the architecture of this plugin can be visualized as shown in the di
 
 #### ⚡️ Requirements
 
-- NeoVim >= 0.8.0
-- [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
+- NeoVim >= 0.11.0
 - [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
 - TypeScript >= 4.0
 - Node supported suitable for TypeScript version you use
@@ -101,7 +100,7 @@ In summary, the architecture of this plugin can be visualized as shown in the di
 ```lua
 use {
   "pmizio/typescript-tools.nvim",
-  requires = { "nvim-lua/plenary.nvim", "neovim/nvim-lspconfig" },
+  requires = { "nvim-lua/plenary.nvim" },
   config = function()
     require("typescript-tools").setup {}
   end,
@@ -109,10 +108,6 @@ use {
 ```
 
 ### ⚙️ Configuration
-
-The parameters passed into the `setup` function are also passed to the standard `nvim-lspconfig`
-server `setup`, allowing you to use the same settings here.
-But you can pass plugin-specific options through the `settings` parameter, which defaults to:
 
 ```lua
 require("typescript-tools").setup {

--- a/lua/typescript-tools/health.lua
+++ b/lua/typescript-tools/health.lua
@@ -1,0 +1,21 @@
+local util = require "typescript-tools.utils"
+
+local M = {}
+
+function M.check()
+  local health = vim.health
+
+  health.start "typescript-tools.nvim"
+
+  local version_ok, version_msg = util.check_minimum_nvim_version()
+  if version_ok then
+    health.ok(version_msg)
+  else
+    health.error(version_msg, {
+      "Please upgrade to Neovim 0.11.2 or later",
+      "Visit https://github.com/neovim/neovim/releases",
+    })
+  end
+end
+
+return M

--- a/lua/typescript-tools/init.lua
+++ b/lua/typescript-tools/init.lua
@@ -1,50 +1,40 @@
-local lspconfig = require "lspconfig"
-local configs = require "lspconfig.configs"
-local util = require "lspconfig.util"
+local util = require "typescript-tools.utils"
 local rpc = require "typescript-tools.rpc"
 local plugin_config = require "typescript-tools.config"
 
 local M = {}
 
 function M.setup(config)
+  local version_ok, version_msg = util.check_minimum_nvim_version()
+  if not version_ok then
+    vim.notify(string.format("[typescript-tools.nvim] %s", version_msg), vim.log.levels.ERROR)
+    return
+  end
   local settings = config.settings or {}
 
   plugin_config.load_settings(settings)
 
-  if configs[plugin_config.plugin_name] == nil then
-    configs[plugin_config.plugin_name] = {
-      default_config = {
-        cmd = function(...)
-          return rpc.start(...)
-        end,
-        filetypes = {
-          "javascript",
-          "javascriptreact",
-          "javascript.jsx",
-          "typescript",
-          "typescriptreact",
-          "typescript.tsx",
-        },
-        root_dir = function(fname)
-          -- INFO: stealed from:
-          -- https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/tsserver.lua#L22
-          local root_dir = util.root_pattern "tsconfig.json"(fname)
-            or util.root_pattern("package.json", "jsconfig.json", ".git")(fname)
-
-          -- INFO: this is needed to make sure we don't pick up root_dir inside node_modules
-          local node_modules_index = root_dir and root_dir:find("node_modules", 1, true)
-          if node_modules_index and node_modules_index > 0 then
-            root_dir = root_dir:sub(1, node_modules_index - 2)
-          end
-
-          return root_dir
-        end,
-        single_file_support = true,
+  if vim.lsp.config[plugin_config.plugin_name] == nil then
+    vim.lsp.config[plugin_config.plugin_name] = {
+      cmd = function(...)
+        return rpc.start(...)
+      end,
+      filetypes = {
+        "javascript",
+        "javascriptreact",
+        "javascript.jsx",
+        "typescript",
+        "typescriptreact",
+        "typescript.tsx",
       },
+      root_dir = function(bufnr, on_dir)
+        on_dir(util.get_root_dir(bufnr))
+      end,
+      single_file_support = true,
     }
   end
 
-  lspconfig[plugin_config.plugin_name].setup(config)
+  vim.lsp.enable(plugin_config.plugin_name)
 end
 
 return M

--- a/lua/typescript-tools/rpc.lua
+++ b/lua/typescript-tools/rpc.lua
@@ -10,7 +10,7 @@ local utils = require "typescript-tools.utils"
 local M = {}
 
 ---@param dispatchers Dispatchers
----@return LspInterface
+---@return vim.lsp.rpc.PublicClient
 function M.start(dispatchers)
   local modified_dispatchers = vim.deepcopy(dispatchers)
   modified_dispatchers.on_exit = utils.run_once(dispatchers.on_exit) -- INFO: multiple calls to on_exit causes errors in nvim lsp

--- a/lua/typescript-tools/tsserver.lua
+++ b/lua/typescript-tools/tsserver.lua
@@ -321,7 +321,7 @@ end
 
 ---@return boolean
 function Tsserver:is_closing()
-  return self.process:is_closing()
+  return self.process ~= nil and self.process:is_closing()
 end
 
 return Tsserver

--- a/lua/typescript-tools/tsserver_provider.lua
+++ b/lua/typescript-tools/tsserver_provider.lua
@@ -2,8 +2,7 @@ local log = require "vim.lsp.log"
 local api = vim.api
 local Path = require "plenary.path"
 local Job = require "plenary.job"
-local configs = require "lspconfig.configs"
-local util = require "lspconfig.util"
+local util = require "typescript-tools.utils"
 
 local plugin_config = require "typescript-tools.config"
 
@@ -58,7 +57,6 @@ end
 function TsserverProvider.new(on_loaded)
   local self = setmetatable({}, { __index = TsserverProvider })
 
-  local config = configs[plugin_config.plugin_name]
   local bufnr = api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(bufnr)
 
@@ -66,7 +64,7 @@ function TsserverProvider.new(on_loaded)
 
   local sanitized_bufname = vim.fs.normalize(bufname)
 
-  self.root_dir = Path:new(config.get_root_dir(sanitized_bufname, bufnr))
+  self.root_dir = Path:new(util.get_root_dir(bufnr))
   self.npm_local_path = find_deep_node_modules_ancestor(sanitized_bufname):joinpath "node_modules"
   self.yarn_sdk_path = find_yarn_sdk(sanitized_bufname):joinpath ".yarn/sdks"
   self.global_install_path = Path:new(vim.fn.resolve(vim.fn.exepath "tsserver")):parent():parent()

--- a/tests/init.lua
+++ b/tests/init.lua
@@ -26,7 +26,6 @@ vim.cmd [[set runtimepath=$VIMRUNTIME]]
 vim.opt.runtimepath:append(get_root())
 vim.opt.packpath = { get_root ".tests/site" }
 load "nvim-lua/plenary.nvim"
-load "neovim/nvim-lspconfig"
 load "nvim-treesitter/nvim-treesitter"
 vim.env.XDG_CONFIG_HOME = get_root ".tests/config"
 vim.env.XDG_DATA_HOME = get_root ".tests/data"


### PR DESCRIPTION
Replace nvim-lspconfig dependency with Neovim's native LSP management APIs (vim.lsp.config and vim.lsp.enable) introduced in v0.11. This eliminates dependency on deprecated nvim-lspconfig APIs and reduces external dependencies.

BREAKING CHANGE: Minimum Neovim version requirement increased to 0.11.0

- Remove nvim-lspconfig dependency from init.lua and README
- Implement native LSP client management using vim.lsp.enable()
- Add health checks for version compatibility
- Refactor utility functions for native API integration