### PR TITLE
feat: better hover

### DIFF
--- a/lua/typescript-tools/protocol/initialize.lua
+++ b/lua/typescript-tools/protocol/initialize.lua
@@ -27,6 +27,7 @@ local configuration = {
       providePrefixAndSuffixTextForRename = true,
       allowRenameOfImportPath = true,
       includePackageJsonAutoImports = "auto",
+      maximumHoverLength = 1000000,
     },
     watchOptions = {},
   },


### PR DESCRIPTION
Default `maximumHoverLength` value is `500`. That means hover
information is truncated for complicated types (usually some parts are
omitted and shown as `...`). This is a little bit annoying as it means
you must go deeper into code and analyze type itself while all info
could be in hover. This change solves this problem.

I have intentionally made this non configurable as I think this should
be default in Neovim.
