### PR TITLE
fix: stop off-by-one read past the last line in semantic tokens

### DIFF
--- a/lua/typescript-tools/protocol/text_document/semantic_tokens.lua
+++ b/lua/typescript-tools/protocol/text_document/semantic_tokens.lua
@@ -62,7 +62,10 @@ local function get_character_position_at_offset(
 
   local current_offset = offset_from_last_iteration
 
-  for line = line_from_last_iteration, #lines_lengths, 1 do
+  -- `line` is a 0-indexed LSP line number indexing the 1-indexed `lines_lengths`,
+  -- so the last valid line is `#lines_lengths - 1`; iterating up to `#lines_lengths`
+  -- reads `lines_lengths[#lines_lengths + 1]` (nil) and errors.
+  for line = line_from_last_iteration, #lines_lengths - 1, 1 do
     local current_line_length = lines_lengths[line + 1]
     local offset_with_current_line = current_offset + current_line_length
 


### PR DESCRIPTION
`get_character_position_at_offset` iterates `line` (a 0-indexed LSP line number) up to `#lines_lengths`, but indexes the 1-indexed `lines_lengths` as `[line + 1]`. On the final iteration that reads `lines_lengths[#lines_lengths + 1]` (nil) and errors:

```
.../protocol/text_document/semantic_tokens.lua:67: attempt to perform arithmetic on local 'current_line_length' (a nil value)
```

Iterating to `#lines_lengths - 1` covers the last line (its index is `#lines_lengths - 1`) without the out-of-bounds read. In-range offsets are unaffected — they return earlier in the loop — and an offset past the end now returns `nil`, matching the documented `LspPosition|nil` return.

Closes #386
